### PR TITLE
Fix broken cmake list append

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if( CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
         CATKIN_DEPENDS plotjuggler
         )
     include_directories(${catkin_INCLUDE_DIRS})
-    list(APPEND ${PJ_LIBRARIES} ${catkin_LIBRARIES} )
+    list(APPEND PJ_LIBRARIES ${catkin_LIBRARIES} )
     set(PJ_PLUGIN_INSTALL_DIRECTORY ${CATKIN_PACKAGE_BIN_DESTINATION} )
 
     #--------------------------------------------------------
@@ -71,7 +71,7 @@ else()
     message(STATUS "plotjuggler_LIBRARIES: ${plotjuggler_LIBRARIES}")
 
     include_directories(${plotjuggler_INCLUDE_DIR})
-    list(APPEND ${PJ_LIBRARIES} ${plotjuggler_LIBRARIES} )
+    list(APPEND PJ_LIBRARIES ${plotjuggler_LIBRARIES} )
     set(PJ_PLUGIN_INSTALL_DIRECTORY bin )
 
 endif()


### PR DESCRIPTION
The CMakeLists.txt had a broken list append syntax that didn't actually append to the list properly. 

When appending to a list in CMake, the variable name needs to be used directly instead of wrapping in `${VAR_NAME}`

